### PR TITLE
Easier setup: auto-detect tracker address if no config file found.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+ipmagnet.ini.php

--- a/README.txt
+++ b/README.txt
@@ -22,13 +22,14 @@ Requirements
 
 Setup
 	Clone the repo into a folder that is available by the httpd.
-	Edit index.php
-		Change the tracker URL (line 2) to point to the public
+	Optionally, copy the sample config file (ipmagnet.ini.php-sample)
+	to ipmagnet.ini.php and change its settings. Options include:
+		Change the tracker URL to point to the public
 		 location of the index.php file.
 	
-		Optionally edit the database path (line 3) if you do not
-		 want to have the database in the same folder for security
-		 reasons.
+		Change the database path to point to the location of the
+		 ipmagnet.db3 file if you want to have the database in a
+		 different folder than index.php for security reasons.
 
 	If you'd like to set a timeout after which clients should recheck their
 	IP against the tracking link, set $enableInterval to true on line 4.

--- a/index.php
+++ b/index.php
@@ -1,6 +1,14 @@
 <?php
-	$TRACKER=urlencode("http://localhost:80/ipmagnet/");
-	$db = new PDO("sqlite:ipmagnet.db3");
+	$cnfgFile=dirname(__FILE__) . '/ipmagnet.ini.php';
+	if(file_exists($cnfgFile)){
+		$cnfg=parse_ini_file($cnfgFile);
+	}
+	$TRACKER = (empty($cnfg['tracker']))
+		? urlencode("http://{$_SERVER['HTTP_HOST']}".dirname($_SERVER['PHP_SELF']).'/')
+		: urlencode($cnfg['tracker']);
+	$db = (empty($cnfg['db_path']))
+		? new PDO("sqlite:ipmagnet.db3")
+		: new PDO("sqlite:$db_path");
 	$enableInterval=false;
 	$trackerInterval=300;
 	

--- a/ipmagnet.ini.php-sample
+++ b/ipmagnet.ini.php-sample
@@ -1,0 +1,19 @@
+; This is a sample configuration for the IPMagnet torrent IP testing tool.
+; It sets the default tracker address that you may wish to use, or modify.
+; Copy this file to `ipmagnet.ini.php`, then make changes there.
+;
+; This file uses "init file" formatting. To learn more about the syntax of this
+; file, please refer to the PHP manual:
+;
+;     http://php.net/parse_ini_file
+;
+;<?php
+; exit('Direct access to this file is prohibited.');
+;// EDIT BELOW THESE LINES.
+;/*
+
+tracker="http://localhost:80/ipmagnet/"
+db_path="ipmagnet.db3"
+
+;*/
+;?>


### PR DESCRIPTION
This commit adds a simple configuration file in PHP `.ini` syntax that
makes it easier to configure the tracker address and the database path.
The result is that no edits to the source code are required to use this.
