### PR TITLE
Echo XML Doctype, to avoid confusion with <? and ?>

### DIFF
--- a/index.php
+++ b/index.php
@@ -119,7 +119,7 @@
 	}
 
 ?>
-<?xml version="1.1" encoding="UTF-8" ?>
+<?php echo '<?xml version="1.1" encoding="UTF-8" ?>'; ?>
 <!DOCTYPE html PUBLIC "-//W3C//DTD XHTML 1.1//EN" "http://www.w3.org/TR/xhtml11/DTD/xhtml11.dtd">
 <html xmlns="http://www.w3.org/1999/xhtml">
 	<head>


### PR DESCRIPTION
PHP is parsing the XML Doctype as a PHP statement, due to the conflict with short tags.

Disabling short tags is pretty overkill, with a simple dirty literal echo!
