### PR TITLE
Check the `hash` parameter

### DIFF
--- a/index.php
+++ b/index.php
@@ -6,8 +6,8 @@
 	
 	$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
 
-  function is_sha1($string){
-			return preg_match('/^[A-Fa-f0-9]{40}$/', $string);
+	function is_sha1($string){
+		return preg_match('/^[A-Fa-f0-9]{40}$/', $string);
 	}
 
 	//BitTorrent clients will submit the info_hash parameter when requesting the magnet link

--- a/index.php
+++ b/index.php
@@ -6,6 +6,10 @@
 	
 	$db->setAttribute(PDO::ATTR_ERRMODE, PDO::ERRMODE_SILENT);
 
+  function is_sha1($string){
+			return preg_match('/^[A-Fa-f0-9]{40}$/', $string);
+	}
+
 	//BitTorrent clients will submit the info_hash parameter when requesting the magnet link
 	if(isset($_GET["info_hash"])){
 
@@ -57,9 +61,9 @@
 	$returnValue["message"]="ok";
 	$returnValue["code"]=0;
 
-	//if a hash was supplied, use it
-	if(isset($_GET["hash"])){
-		$HASH=htmlentities($_GET["hash"], ENT_QUOTES);
+	//if a hash was supplied and it's a valid sha1 hash, use it
+	if(isset($_GET["hash"]) && is_sha1($_GET["hash"])){
+		$HASH=strtolower($_GET["hash"]);
 	}
 	//else, generate a new one
 	else{


### PR DESCRIPTION
The parameter hash can be used to trick someone into downloading a "real" torrent with additional trackers.
For example if the hash parameter is `b6590b0f371061af7b907c39ea909874d7bd9b06%26tr%3Dhttp%253A%252F%252Fbttracker.debian.org%253A6969%252Fannounce`
which is the urlencoding of `b6590b0f371061af7b907c39ea909874d7bd9b06&tr=http%3A%2F%2Fbttracker.debian.org%3A6969%2Fannounce`
will generate  a magnet link which downloads a debian image.

Instead of url-encoding the hash value I added a check to see if it is a valid hash (only hex-characters and 40 characters long).
